### PR TITLE
Feature/suppress accessories

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,29 @@ Add the plugin to the **platforms** section in your homebridge configuration fil
 
 ### More Configuration Options
 
+#### Verbose Logging
+
 Another configuration option is de `verbose` switch. It cranks up the information that is published to the logs. This is still at an informational level and can help in detecting anomalies. To really see debugging level details, run homebridge with the `-D` switch.
+
+#### Suppressing Accessories
+
+Besides the required `host` & `password` and other connection-related configuraion options, the configuration also allows for suppressing accessories:
+
+```json
+  "platforms": [
+    {
+      "platform" : "NHC2",
+      "name" : "NHC2",
+      "host": "<IP_ADDRESS_OF_YOUR_CONNECTED_CONTROLLER>",
+      "password": "<PASSWORD_PROVIDED_BY_MYNIKOHOMECONTROLL>",
+      "suppressedAccessories": [
+          "fa33d687-9225-4f9e-b55e-013abb69b42e"
+      ]
+    }
+  ]
+```
+
+This allows for not exposing certain accessories to Homebrigde (and therefore also the Home app). This feature can be useful when sharing access to the Home app with others. 
 
 ## Plugin Development
 

--- a/src/nhc2-platform.ts
+++ b/src/nhc2-platform.ts
@@ -51,8 +51,9 @@ class NHC2Platform implements DynamicPlatformPlugin {
     this.suppressedAccessories = config.suppressedAccessories || [];
     if(this.suppressedAccessories) {
       this.log.info("Suppressing accessories: ");
+      var self = this;
       this.suppressedAccessories.forEach(function(acc) {
-        this.log.info("  - " + acc);
+        self.log.info("  - " + acc);
       });
     }
     this.nhc2 = new NHC2("mqtts://" + config.host, {

--- a/src/nhc2-platform.ts
+++ b/src/nhc2-platform.ts
@@ -47,7 +47,7 @@ class NHC2Platform implements DynamicPlatformPlugin {
     private api: API,
   ) {
     this.log = new NHC2Logger(logger, config);
-
+    this.config = config;
     this.nhc2 = new NHC2("mqtts://" + config.host, {
       port: config.port || 8884,
       clientId: config.clientId || "NHC2-homebridge",
@@ -120,7 +120,11 @@ class NHC2Platform implements DynamicPlatformPlugin {
 
     Object.keys(mapping).forEach(model => {
       const config = mapping[model];
-      const accs = accessories.filter(acc => acc.Model === model);
+      const accs = accessories.filter(acc =>
+        ! this.config.suppressedAccessories.includes(acc.Uuid)
+        &&
+        acc.Model === model
+      );
       accs.forEach(acc => {
         const newAccessory = new Accessory(acc.Name as string, acc.Uuid);
         const newService = new config.service(acc.Name);

--- a/src/nhc2-platform.ts
+++ b/src/nhc2-platform.ts
@@ -37,6 +37,7 @@ class NHC2Platform implements DynamicPlatformPlugin {
     .Characteristic;
 
   private readonly accessories: PlatformAccessory[] = [];
+  private readonly suppressedAccessories: string[] = [];
   private readonly nhc2: NHC2;
 
   private readonly log: NHC2Logger;
@@ -47,7 +48,13 @@ class NHC2Platform implements DynamicPlatformPlugin {
     private api: API,
   ) {
     this.log = new NHC2Logger(logger, config);
-    this.config = config;
+    this.suppressedAccessories = config.suppressedAccessories || [];
+    if(this.suppressedAccessories) {
+      this.log.info("Suppressing accessories: ");
+      this.suppressedAccessories.forEach(function(acc) {
+        this.log.info("  - " + acc);
+      });
+    }
     this.nhc2 = new NHC2("mqtts://" + config.host, {
       port: config.port || 8884,
       clientId: config.clientId || "NHC2-homebridge",
@@ -121,7 +128,7 @@ class NHC2Platform implements DynamicPlatformPlugin {
     Object.keys(mapping).forEach(model => {
       const config = mapping[model];
       const accs = accessories.filter(acc =>
-        ! this.config.suppressedAccessories.includes(acc.Uuid)
+        ! this.suppressedAccessories.includes(acc.Uuid)
         &&
         acc.Model === model
       );


### PR DESCRIPTION
This PR adds a configuration option to suppress certain accessories (by UUID). A use case for this option is to be able to not expose certain accessories to other persons, with whom the Home app is shared (e.g. external access,...)